### PR TITLE
[Feat] 대기석 및 좌우측 셀 이동 방지 로직 추가 및 BFS 로직 추가

### DIFF
--- a/Assets/Min/Scenes/TestScene.unity
+++ b/Assets/Min/Scenes/TestScene.unity
@@ -132,7 +132,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.96
+      value: -3.18
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
@@ -140,7 +140,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.72
+      value: 9.22
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
@@ -179,7 +179,7 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &78143449
+--- !u!1001 &353496777
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -187,56 +187,56 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.075899124
+      value: -13.22
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.3
+      value: 0.83
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 11.903775
+      value: 10.71
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Monster Melee
+      value: Hero Melee (10)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
---- !u!1001 &549039210
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &369234155
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -244,60 +244,56 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.87
+      value: 1.06
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.15
+      value: 0.83
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 13.34
+      value: 10.71
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Monster Melee (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8814268374718235948, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
-      propertyPath: attackRange
-      value: 2
+      value: Hero Melee (5)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
---- !u!1001 &617292767
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &378747185
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -305,55 +301,112 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.85878944
+      value: -4.36
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.28
+      value: 0.83
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 16.431553
+      value: 10.71
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Monster Ranger
+      value: Hero Melee (3)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &577624570
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1001 &677874733
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -364,7 +417,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -13.78031
+      value: -2.71
       objectReference: {fileID: 0}
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalPosition.y
@@ -411,67 +464,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
---- !u!1001 &860316194
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -9.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.29
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.14
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6214499957446047406, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: attackRange
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1 &943676835
 GameObject:
   m_ObjectHideFlags: 0
@@ -566,7 +558,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1001 &995023584
+--- !u!1001 &1133159043
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -574,55 +566,112 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.19076729
+      value: -6.17
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.29
+      value: 0.83
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 6.0484977
+      value: 10.71
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Hero Ranger
+      value: Hero Melee (6)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &1172445182
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1001 &1237570186
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -680,7 +729,7 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
---- !u!1001 &1241259126
+--- !u!1001 &1281549100
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -688,55 +737,55 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -9.35948
+      value: -0.65
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.39
+      value: 0.83
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 16.286001
+      value: 10.71
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Monster Ranger (1)
+      value: Hero Melee (4)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1 &1499918983
 GameObject:
   m_ObjectHideFlags: 0
@@ -829,64 +878,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1711885661
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -12.148228
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.07
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 6.200687
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
-      propertyPath: m_Name
-      value: Hero Ranger (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
---- !u!1001 &1926625773
+--- !u!1001 &1509386450
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -896,15 +888,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -12.962538
+      value: -7.93
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.31
+      value: 0.83
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.641262
+      value: 10.71
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
@@ -936,7 +928,64 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Hero Melee (2)
+      value: Hero Melee (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &1600174940
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee (8)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -950,13 +999,14 @@ SceneRoots:
   - {fileID: 1499918986}
   - {fileID: 943676837}
   - {fileID: 1237570186}
-  - {fileID: 617292767}
-  - {fileID: 1241259126}
-  - {fileID: 78143449}
   - {fileID: 677874733}
-  - {fileID: 549039210}
-  - {fileID: 995023584}
-  - {fileID: 1711885661}
-  - {fileID: 860316194}
   - {fileID: 8617454}
-  - {fileID: 1926625773}
+  - {fileID: 577624570}
+  - {fileID: 1281549100}
+  - {fileID: 369234155}
+  - {fileID: 1133159043}
+  - {fileID: 1509386450}
+  - {fileID: 1600174940}
+  - {fileID: 1172445182}
+  - {fileID: 353496777}
+  - {fileID: 378747185}

--- a/Assets/Min/Scenes/TestScene.unity
+++ b/Assets/Min/Scenes/TestScene.unity
@@ -122,592 +122,356 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &258496973
-GameObject:
+--- !u!1001 &8617454
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 258496977}
-  - component: {fileID: 258496976}
-  - component: {fileID: 258496975}
-  - component: {fileID: 258496974}
-  m_Layer: 0
-  m_Name: Hero (1)
-  m_TagString: Hero
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &258496974
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258496973}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &258496975
-MeshRenderer:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.83
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+--- !u!1001 &78143449
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258496973}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &258496976
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258496973}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &258496977
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258496973}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.42, y: 2, z: -2.35}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &308695053
-GameObject:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.075899124
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.903775
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_Name
+      value: Monster Melee
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+--- !u!1001 &549039210
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 308695058}
-  - component: {fileID: 308695057}
-  - component: {fileID: 308695056}
-  - component: {fileID: 308695055}
-  - component: {fileID: 308695054}
-  m_Layer: 0
-  m_Name: Enemy
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &308695054
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308695053}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 2113270552}
-  moveInterval: 1
-  moveDuration: 0.25
-  attackRange: 1
---- !u!136 &308695055
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308695053}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &308695056
-MeshRenderer:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_Name
+      value: Monster Melee (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8814268374718235948, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: attackRange
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+--- !u!1001 &617292767
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308695053}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &308695057
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308695053}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &308695058
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 308695053}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.06, y: 2, z: -4.58}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &513426832
-GameObject:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.85878944
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.431553
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_Name
+      value: Monster Ranger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+--- !u!1001 &677874733
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 513426836}
-  - component: {fileID: 513426835}
-  - component: {fileID: 513426834}
-  - component: {fileID: 513426833}
-  m_Layer: 0
-  m_Name: Hero (2)
-  m_TagString: Hero
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &513426833
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513426832}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &513426834
-MeshRenderer:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.78031
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.251812
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_Name
+      value: Monster Melee (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+--- !u!1001 &860316194
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513426832}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &513426835
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513426832}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &513426836
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 513426832}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.42, y: 2, z: -0.69}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &607505571
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 607505576}
-  - component: {fileID: 607505575}
-  - component: {fileID: 607505574}
-  - component: {fileID: 607505573}
-  - component: {fileID: 607505572}
-  m_Layer: 0
-  m_Name: Enemy (4)
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &607505572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 607505571}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 2113270552}
-  moveInterval: 1
-  moveDuration: 0.25
-  attackRange: 1
---- !u!136 &607505573
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 607505571}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &607505574
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 607505571}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &607505575
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 607505571}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &607505576
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 607505571}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.12, y: 2, z: -3.78}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &623124885
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 623124890}
-  - component: {fileID: 623124889}
-  - component: {fileID: 623124888}
-  - component: {fileID: 623124887}
-  - component: {fileID: 623124886}
-  m_Layer: 0
-  m_Name: Enemy (2)
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &623124886
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623124885}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 2113270552}
-  moveInterval: 1
-  moveDuration: 0.25
-  attackRange: 3
---- !u!136 &623124887
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623124885}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &623124888
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623124885}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &623124889
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623124885}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &623124890
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623124885}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.5, y: 2, z: -3.84}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6214499957446047406, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: attackRange
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1 &943676835
 GameObject:
   m_ObjectHideFlags: 0
@@ -802,6 +566,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &995023584
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.19076729
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.0484977
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_Name
+      value: Hero Ranger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
 --- !u!1001 &1237570186
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -859,113 +680,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
---- !u!1 &1380421496
-GameObject:
+--- !u!1001 &1241259126
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1380421500}
-  - component: {fileID: 1380421499}
-  - component: {fileID: 1380421498}
-  - component: {fileID: 1380421497}
-  m_Layer: 0
-  m_Name: Hero
-  m_TagString: Hero
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &1380421497
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380421496}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1380421498
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380421496}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1380421499
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380421496}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1380421500
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380421496}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.19, y: 2, z: -2.35}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.35948
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.286001
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_Name
+      value: Monster Ranger (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
 --- !u!1 &1499918983
 GameObject:
   m_ObjectHideFlags: 0
@@ -1058,259 +829,120 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1506788964
-GameObject:
+--- !u!1001 &1711885661
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1506788969}
-  - component: {fileID: 1506788968}
-  - component: {fileID: 1506788967}
-  - component: {fileID: 1506788966}
-  - component: {fileID: 1506788965}
-  m_Layer: 0
-  m_Name: Enemy (1)
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1506788965
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1506788964}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 2113270552}
-  moveInterval: 1
-  moveDuration: 0.25
-  attackRange: 1
---- !u!136 &1506788966
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1506788964}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1506788967
-MeshRenderer:
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.148228
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.200687
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      propertyPath: m_Name
+      value: Hero Ranger (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+--- !u!1001 &1926625773
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1506788964}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1506788968
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1506788964}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1506788969
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1506788964}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.09, y: 2, z: -4.58}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1758440304
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1758440309}
-  - component: {fileID: 1758440308}
-  - component: {fileID: 1758440307}
-  - component: {fileID: 1758440306}
-  - component: {fileID: 1758440305}
-  m_Layer: 0
-  m_Name: Enemy (3)
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1758440305
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1758440304}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 2113270552}
-  moveInterval: 1
-  moveDuration: 0.25
-  attackRange: 1
---- !u!136 &1758440306
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1758440304}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1758440307
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1758440304}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1758440308
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1758440304}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1758440309
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1758440304}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.12, y: 2, z: -4.58}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1839735485 &2113270552 stripped
-Tilemap:
-  m_CorrespondingSourceObject: {fileID: 3076721618882970550, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
-  m_PrefabInstance: {fileID: 1237570186}
-  m_PrefabAsset: {fileID: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.962538
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.641262
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      propertyPath: m_Name
+      value: Hero Melee (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1318,11 +950,13 @@ SceneRoots:
   - {fileID: 1499918986}
   - {fileID: 943676837}
   - {fileID: 1237570186}
-  - {fileID: 308695058}
-  - {fileID: 623124890}
-  - {fileID: 1758440309}
-  - {fileID: 607505576}
-  - {fileID: 1506788969}
-  - {fileID: 1380421500}
-  - {fileID: 258496977}
-  - {fileID: 513426836}
+  - {fileID: 617292767}
+  - {fileID: 1241259126}
+  - {fileID: 78143449}
+  - {fileID: 677874733}
+  - {fileID: 549039210}
+  - {fileID: 995023584}
+  - {fileID: 1711885661}
+  - {fileID: 860316194}
+  - {fileID: 8617454}
+  - {fileID: 1926625773}

--- a/Assets/Min/Scripts/Test/BlockedCellManager.cs
+++ b/Assets/Min/Scripts/Test/BlockedCellManager.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class BlockedCellManager
+{
+    private static HashSet<Vector2Int> blockedCells = new HashSet<Vector2Int>();
+
+    static BlockedCellManager()
+    {
+        for (int x = -9; x <= 1; x++)
+            blockedCells.Add(new Vector2Int(x, 3));
+
+        for (int x = -9; x <= 2; x++)
+            blockedCells.Add(new Vector2Int(x, 12));
+
+        for (int y = 4; y <= 11; y++)
+            blockedCells.Add(new Vector2Int(1, y));
+
+        for (int y = 4; y <= 11; y++)
+            blockedCells.Add(new Vector2Int(-9, y));
+    }
+
+    public static bool IsBlocked(Vector2Int cellPos)
+    {
+        return blockedCells.Contains(cellPos);
+    }
+}

--- a/Assets/Min/Scripts/Test/BlockedCellManager.cs.meta
+++ b/Assets/Min/Scripts/Test/BlockedCellManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb43b0df3b2e56c4095b34c3795a7c4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Materials.meta
+++ b/Assets/Min/Scripts/Test/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e97d4389b5a81d4f8ae0ed33ffe2398
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Materials/Enemy Melee Mat.mat
+++ b/Assets/Min/Scripts/Test/Materials/Enemy Melee Mat.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Enemy Melee Mat
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Min/Scripts/Test/Materials/Enemy Melee Mat.mat.meta
+++ b/Assets/Min/Scripts/Test/Materials/Enemy Melee Mat.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d50ccfbfd992cf49b1bf31da9a718b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Materials/Enemy Ranger Mat.mat
+++ b/Assets/Min/Scripts/Test/Materials/Enemy Ranger Mat.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Enemy Ranger Mat
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0.504717, b: 0.504717, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Min/Scripts/Test/Materials/Enemy Ranger Mat.mat.meta
+++ b/Assets/Min/Scripts/Test/Materials/Enemy Ranger Mat.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6509e859e9c0b564f80faa5fce6b1bc4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Materials/Hero Melee Mat 1.mat
+++ b/Assets/Min/Scripts/Test/Materials/Hero Melee Mat 1.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hero Melee Mat 1
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0.33355236, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Min/Scripts/Test/Materials/Hero Melee Mat 1.mat.meta
+++ b/Assets/Min/Scripts/Test/Materials/Hero Melee Mat 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b38d7c16b561848419cfbeb524bb223a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Materials/Hero Ranger Mat 2.mat
+++ b/Assets/Min/Scripts/Test/Materials/Hero Ranger Mat 2.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hero Ranger Mat 2
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.6745283, g: 0.68590844, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Min/Scripts/Test/Materials/Hero Ranger Mat 2.mat.meta
+++ b/Assets/Min/Scripts/Test/Materials/Hero Ranger Mat 2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da277d76b3a24194db6d0210df48af2b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Prefabs.meta
+++ b/Assets/Min/Scripts/Test/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8a46e70a14bf724f92778f9b432d78a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Prefabs/Hero Melee.prefab
+++ b/Assets/Min/Scripts/Test/Prefabs/Hero Melee.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6958677851766078136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2357903795028269578}
+  - component: {fileID: 3806295020948910591}
+  - component: {fileID: 5622903734398727718}
+  - component: {fileID: 1051464575367865809}
+  - component: {fileID: 6214499957446047406}
+  m_Layer: 0
+  m_Name: Hero Melee
+  m_TagString: Hero
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2357903795028269578
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6958677851766078136}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.03, y: 1.33, z: 10.31}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3806295020948910591
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6958677851766078136}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5622903734398727718
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6958677851766078136}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b38d7c16b561848419cfbeb524bb223a, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &1051464575367865809
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6958677851766078136}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &6214499957446047406
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6958677851766078136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tilemap: {fileID: 0}
+  targetTag: Monster
+  moveInterval: 1
+  moveDuration: 0.25
+  attackRange: 1
+  ObjYPos: 1.5

--- a/Assets/Min/Scripts/Test/Prefabs/Hero Melee.prefab.meta
+++ b/Assets/Min/Scripts/Test/Prefabs/Hero Melee.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 467ce242d8b17344fa7502c932038714
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Prefabs/Hero Ranger.prefab
+++ b/Assets/Min/Scripts/Test/Prefabs/Hero Ranger.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8488796428882984561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3574251028138415600}
+  - component: {fileID: 8183406778252896878}
+  - component: {fileID: 1541038436182816067}
+  - component: {fileID: 496528942355039769}
+  - component: {fileID: 4528052102136916369}
+  m_Layer: 0
+  m_Name: Hero Ranger
+  m_TagString: Hero
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3574251028138415600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488796428882984561}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.14, y: 1.33, z: 5.92}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8183406778252896878
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488796428882984561}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1541038436182816067
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488796428882984561}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: da277d76b3a24194db6d0210df48af2b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &496528942355039769
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488796428882984561}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4528052102136916369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488796428882984561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tilemap: {fileID: 0}
+  targetTag: Monster
+  moveInterval: 1
+  moveDuration: 0.25
+  attackRange: 3
+  ObjYPos: 1.5

--- a/Assets/Min/Scripts/Test/Prefabs/Hero Ranger.prefab.meta
+++ b/Assets/Min/Scripts/Test/Prefabs/Hero Ranger.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3388643a90d4ab74c95ff2445e23527b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Prefabs/Monster Melee.prefab
+++ b/Assets/Min/Scripts/Test/Prefabs/Monster Melee.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7152927933751008845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 560843773711746409}
+  - component: {fileID: 1432449297032819148}
+  - component: {fileID: 1679495440376214777}
+  - component: {fileID: 9102122357473712728}
+  - component: {fileID: 8814268374718235948}
+  m_Layer: 0
+  m_Name: Monster Melee
+  m_TagString: Monster
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &560843773711746409
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152927933751008845}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -8.62, y: 1.33, z: 11.86}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1432449297032819148
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152927933751008845}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1679495440376214777
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152927933751008845}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0d50ccfbfd992cf49b1bf31da9a718b3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &9102122357473712728
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152927933751008845}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8814268374718235948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7152927933751008845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tilemap: {fileID: 0}
+  targetTag: Hero
+  moveInterval: 1
+  moveDuration: 0.25
+  attackRange: 1
+  ObjYPos: 1.5

--- a/Assets/Min/Scripts/Test/Prefabs/Monster Melee.prefab.meta
+++ b/Assets/Min/Scripts/Test/Prefabs/Monster Melee.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d8d26febc23b08b4ba5cc93f2c06a616
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/Prefabs/Monster Ranger.prefab
+++ b/Assets/Min/Scripts/Test/Prefabs/Monster Ranger.prefab
@@ -1,0 +1,128 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7664697950509709105
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 750738757089174787}
+  - component: {fileID: 2233144200078620160}
+  - component: {fileID: 3069094953487099637}
+  - component: {fileID: 523230670204722587}
+  - component: {fileID: 3443393835392537137}
+  m_Layer: 0
+  m_Name: Monster Ranger
+  m_TagString: Monster
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &750738757089174787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7664697950509709105}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.95, y: 1.33, z: 16.63}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2233144200078620160
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7664697950509709105}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &3069094953487099637
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7664697950509709105}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 6509e859e9c0b564f80faa5fce6b1bc4, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &523230670204722587
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7664697950509709105}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3443393835392537137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7664697950509709105}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d469e5a4a22a164a98305f0a28c856f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tilemap: {fileID: 0}
+  targetTag: Hero
+  moveInterval: 1
+  moveDuration: 0.25
+  attackRange: 3
+  ObjYPos: 1.5

--- a/Assets/Min/Scripts/Test/Prefabs/Monster Ranger.prefab.meta
+++ b/Assets/Min/Scripts/Test/Prefabs/Monster Ranger.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 06dadf9422f985345baeaca6935449ff
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/TraceTest.cs
+++ b/Assets/Min/Scripts/Test/TraceTest.cs
@@ -189,7 +189,9 @@ public class TraceTest : MonoBehaviour
         {
             Vector2Int candidate = from + dir;
 
-            if (IsCellOccupied(candidate) || TileReservation.IsReserved(candidate))
+            if (IsCellOccupied(candidate) 
+                || TileReservation.IsReserved(candidate) 
+                || BlockedCellManager.IsBlocked(candidate))
             {
                 Debug.Log($"{name} 후보 {candidate} 는 점유 중");
                 continue;

--- a/Assets/Min/Scripts/Test/TraceTest.cs
+++ b/Assets/Min/Scripts/Test/TraceTest.cs
@@ -14,8 +14,11 @@ public class TraceTest : MonoBehaviour
     [SerializeField] private float moveDuration = 0.25f; // 이동 시간
     [SerializeField] private int attackRange = 3; // 감지 범위, 공격 사거리랑 다름
 
+    [SerializeField] private float ObjYPos = 1.5f;
+
     private bool isMoving = false;
     private Coroutine unitCoroutine;
+
 
     private void Start()
     {
@@ -85,7 +88,7 @@ public class TraceTest : MonoBehaviour
                 }
 
                 Vector3 targetPos = tilemap.GetCellCenterWorld(new Vector3Int(nextXY.x, nextXY.y, 0));
-                targetPos.y = 2f;
+                targetPos.y = ObjYPos;
                 StartCoroutine(MoveTo(targetPos));
             }
 
@@ -189,8 +192,8 @@ public class TraceTest : MonoBehaviour
         {
             Vector2Int candidate = from + dir;
 
-            if (IsCellOccupied(candidate) 
-                || TileReservation.IsReserved(candidate) 
+            if (IsCellOccupied(candidate)
+                || TileReservation.IsReserved(candidate)
                 || BlockedCellManager.IsBlocked(candidate))
             {
                 Debug.Log($"{name} 후보 {candidate} 는 점유 중");

--- a/Assets/Min/Scripts/Test/TraceTest.cs
+++ b/Assets/Min/Scripts/Test/TraceTest.cs
@@ -171,51 +171,6 @@ public class TraceTest : MonoBehaviour
         return new Vector3Int(x, y, z);
     }
 
-    // 한 칸 검사
-
-    //private Vector2Int GetStepToward(Vector2Int from, Vector2Int to)
-    //{
-    //    Vector2Int[] directionsEven = {
-    //        new Vector2Int(1, 0), new Vector2Int(0, 1), new Vector2Int(-1, 1),
-    //        new Vector2Int(-1, 0), new Vector2Int(-1, -1), new Vector2Int(0, -1)
-    //    };
-
-    //    Vector2Int[] directionsOdd = {
-    //        new Vector2Int(1, 0), new Vector2Int(1, 1), new Vector2Int(0, 1),
-    //        new Vector2Int(-1, 0), new Vector2Int(0, -1), new Vector2Int(1, -1)
-    //    };
-
-    //    Vector2Int[] directions = (from.y % 2 == 0) ? directionsEven : directionsOdd;
-
-    //    Vector2Int best = Vector2Int.zero;
-    //    int minDist = int.MaxValue;
-
-    //    foreach (Vector2Int dir in directions)
-    //    {
-    //        Vector2Int candidate = from + dir;
-
-    //        if (IsCellOccupied(candidate)
-    //            || TileReservation.IsReserved(candidate)
-    //            || BlockedCellManager.IsBlocked(candidate))
-    //        {
-    //            Debug.Log($"{name} 후보 {candidate} 는 점유 중");
-    //            continue;
-    //        }
-
-    //        int dist = HexDistance(candidate, to);
-    //        Debug.Log($"{name} 후보 {candidate} 거리: {dist}");
-
-    //        if (dist <= minDist)
-    //        {
-    //            minDist = dist;
-    //            best = dir;
-    //        }
-    //    }
-
-    //    return best;
-    //}
-
-
     // BFS
 
     private Vector2Int GetStepToward(Vector2Int from, Vector2Int to)
@@ -230,8 +185,8 @@ public class TraceTest : MonoBehaviour
         new Vector2Int(-1, 0), new Vector2Int(0, -1), new Vector2Int(1, -1)
     };
 
-        Queue<Vector2Int> queue = new();
-        Dictionary<Vector2Int, Vector2Int> cameFrom = new();
+        Queue<Vector2Int> queue = new Queue<Vector2Int>();
+        Dictionary<Vector2Int, Vector2Int> cameFrom = new Dictionary<Vector2Int, Vector2Int>();
 
         queue.Enqueue(from);
         cameFrom[from] = from;


### PR DESCRIPTION
1. 대기석 및 좌우측 셀 이동 방지 로직 추가
2. 오브젝트의 포지션 y값을 인스펙터에서 조절할 수 있도록 수정
3. 이동 로직 한 칸 검사 후 가까워지는 셀로 이동하는 로직에서 BFS로 수정
4. 테스트씬 수정 및 기물 프리팹 추가