### PR TITLE
[Feat] 히어로 RankUp 기능 구현, 제거된 Hero에 대한 참조 문제로 버그 존재함.

### DIFF
--- a/Assets/YongSeok/Scene/YSGameScene.unity
+++ b/Assets/YongSeok/Scene/YSGameScene.unity
@@ -240,11 +240,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6801752}
-  - component: {fileID: 6801756}
-  - component: {fileID: 6801755}
-  - component: {fileID: 6801754}
+  - component: {fileID: 6801751}
   - component: {fileID: 6801753}
-  - component: {fileID: 6801757}
+  - component: {fileID: 6801754}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -252,6 +250,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &6801751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6801750}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d3c8ded10a1d9e429976d55bb6abf18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 23105991}
+  startPanel: {fileID: 0}
+  playerObject: {fileID: 23105990}
+  startBtn: {fileID: 0}
+  endBtn: {fileID: 0}
 --- !u!4 &6801752
 Transform:
   m_ObjectHideFlags: 0
@@ -274,12 +289,12 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6801750}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7a6a1a0788fd574ba5db16b442d76ff, type: 3}
+  m_Script: {fileID: 11500000, guid: 5a94e4ecbde0c7d4cab4c80cedc309df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefab: {fileID: 6758666376273876375, guid: 3a1ef3a62621276428b7ea11055e4497, type: 3}
+  info: {fileID: 1258515243}
 --- !u!114 &6801754
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -289,62 +304,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 6801750}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b7a6a1a0788fd574ba5db16b442d76ff, type: 3}
+  m_Script: {fileID: 11500000, guid: 520339e45883c4e47854fc7f285d4e67, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefab: {fileID: 6758666376273876375, guid: 4cac2150bff9af1439381b6d9393ae65, type: 3}
---- !u!114 &6801755
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6801750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f414b96e99ce2e3429334b28d1cdc0c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6801756
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6801750}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 93c5939b694347441b2100b70578d5d4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  heroPrefabs:
-  - {fileID: 6801754}
-  - {fileID: 6801753}
-  tilemap: {fileID: 971259837}
-  heroManager: {fileID: 6801755}
---- !u!114 &6801757
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6801750}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3c7d630ca4fa42a47b1850dd00aba7e8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  tilemap: {fileID: 971259837}
-  tileRoot: {fileID: 971259838}
-  markerPrefab: {fileID: 6758666376273876375, guid: 4cac2150bff9af1439381b6d9393ae65, type: 3}
-  manuallySelectedTiles:
-  - {x: -4, y: 3, z: 1}
-  - {x: 0, y: 3, z: 1}
-  - {x: -8, y: 3, z: 1}
-  useRadiusSelection: 0
-  center: {x: -4, y: 3, z: 0}
-  radius: 2
-  foundTilePositions: []
 --- !u!1 &23105990
 GameObject:
   m_ObjectHideFlags: 0
@@ -355,6 +317,7 @@ GameObject:
   m_Component:
   - component: {fileID: 23105992}
   - component: {fileID: 23105991}
+  - component: {fileID: 23105993}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -374,6 +337,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f092a5b4c428a9540b9a336f41faf382, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  info: {fileID: 1258515243}
   health: 100
   maxHealth: 0
   gold: 0
@@ -381,6 +345,8 @@ MonoBehaviour:
   maxExp: 0
   level: 2
   stage: 1
+  playerHero: {fileID: 23105993}
+  tileMap: {fileID: 657215050}
 --- !u!4 &23105992
 Transform:
   m_ObjectHideFlags: 0
@@ -396,6 +362,22 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &23105993
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 23105990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf62c64b1e47bbf458ca822b57462447, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  allHero: []
+  storageHero: []
+  battleHero: []
+  tileMap: {fileID: 971259837}
 --- !u!1001 &52701943
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -602,6 +584,142 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 66978695}
+  m_CullTransparentMesh: 1
+--- !u!1 &78341094
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 78341095}
+  - component: {fileID: 78341097}
+  - component: {fileID: 78341096}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &78341095
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 78341094}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1318583817}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &78341096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 78341094}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Sell
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &78341097
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 78341094}
   m_CullTransparentMesh: 1
 --- !u!114 &79786331 stripped
 MonoBehaviour:
@@ -852,9 +970,25 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 3150228807321702912, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
+      propertyPath: tile
+      value: 
+      objectReference: {fileID: 657215050}
+    - target: {fileID: 3150228807321702912, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
       propertyPath: _tileMap
       value: 
       objectReference: {fileID: 971259837}
+    - target: {fileID: 3150228807321702912, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
+      propertyPath: heroInfo
+      value: 
+      objectReference: {fileID: 889372134}
+    - target: {fileID: 3150228807321702912, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
+      propertyPath: heroImage
+      value: 
+      objectReference: {fileID: 1785288480}
+    - target: {fileID: 3150228807321702912, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
+      propertyPath: playerHero
+      value: 
+      objectReference: {fileID: 23105993}
     - target: {fileID: 4265049954739200834, guid: b3d9a1b2dbe066e4fb0342a25cceb545, type: 3}
       propertyPath: m_LocalPosition.x
       value: -3.031135
@@ -987,7 +1121,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 142.63345
+      value: 157.36655
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.y
@@ -1023,7 +1157,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 499.2171
+      value: 550.7829
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1057,6 +1191,140 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &546651228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 546651229}
+  - component: {fileID: 546651231}
+  - component: {fileID: 546651230}
+  m_Layer: 5
+  m_Name: Stage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &546651229
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546651228}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1410711696}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -10.00795}
+  m_SizeDelta: {x: 98, y: 20.0159}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &546651230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546651228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Stage
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 10
+  m_fontSizeBase: 10
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &546651231
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 546651228}
+  m_CullTransparentMesh: 1
 --- !u!156049354 &581364325 stripped
 Grid:
   m_CorrespondingSourceObject: {fileID: 7559697447956695434, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
@@ -1071,6 +1339,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &657215050 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2044586320894874439, guid: 6674a989504bb8b40834bfa2399d866c, type: 3}
+  m_PrefabInstance: {fileID: 859958218}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a8300ad05245fb4ba3c83c743f307e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &661145530
@@ -1131,7 +1410,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 142.63345
+      value: 157.36655
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.y
@@ -1167,7 +1446,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 71.31673
+      value: 78.68327
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -1559,6 +1838,8 @@ RectTransform:
   m_Children:
   - {fileID: 784674208}
   - {fileID: 2042921658}
+  - {fileID: 1410711696}
+  - {fileID: 889372135}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1809,13 +2090,13 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 581364325}
     - target: {fileID: 2044586320894874439, guid: 6674a989504bb8b40834bfa2399d866c, type: 3}
-      propertyPath: _tileMap
+      propertyPath: tileMap
       value: 
       objectReference: {fileID: 971259837}
     - target: {fileID: 2044586320894874439, guid: 6674a989504bb8b40834bfa2399d866c, type: 3}
-      propertyPath: _mainCamera
+      propertyPath: _tileMap
       value: 
-      objectReference: {fileID: 963194227}
+      objectReference: {fileID: 971259837}
     - target: {fileID: 2155499169226051952, guid: 6674a989504bb8b40834bfa2399d866c, type: 3}
       propertyPath: m_Name
       value: TileMapManager
@@ -1881,6 +2162,100 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &889372134
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 889372135}
+  - component: {fileID: 889372138}
+  - component: {fileID: 889372137}
+  - component: {fileID: 889372139}
+  m_Layer: 5
+  m_Name: HeroInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &889372135
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889372134}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1785288479}
+  - {fileID: 1317431637}
+  - {fileID: 1318583817}
+  m_Father: {fileID: 746897330}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -92.79999, y: 45.97216}
+  m_SizeDelta: {x: 157, y: 262.9962}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &889372137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889372134}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &889372138
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889372134}
+  m_CullTransparentMesh: 1
+--- !u!114 &889372139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889372134}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4b852e12d9b1784ca6476973bce3cae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hero: {fileID: 0}
+  heroImage: {fileID: 1785288480}
+  sellBtn: {fileID: 1318583818}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -2112,11 +2487,6 @@ Tilemap:
   m_CorrespondingSourceObject: {fileID: 3076721618882970550, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
   m_PrefabInstance: {fileID: 52701943}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &971259838 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 267600264036123232, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
-  m_PrefabInstance: {fileID: 52701943}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &983411057 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5765122945223944912, guid: baee6f97abd3459479c916598232ba22, type: 3}
@@ -2182,6 +2552,266 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1258515243 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8832584231937900903, guid: 748af801eb100954da24e6256356feb2, type: 3}
+  m_PrefabInstance: {fileID: 8369316306744963872}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1317431636
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1317431637}
+  - component: {fileID: 1317431639}
+  - component: {fileID: 1317431638}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1317431637
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317431636}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 889372135}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1317431638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317431636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Hero Info
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1317431639
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1317431636}
+  m_CullTransparentMesh: 1
+--- !u!1 &1318583816
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1318583817}
+  - component: {fileID: 1318583820}
+  - component: {fileID: 1318583819}
+  - component: {fileID: 1318583818}
+  m_Layer: 5
+  m_Name: SellBtn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1318583817
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1318583816}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 78341095}
+  m_Father: {fileID: 889372135}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -0.000013351, y: 26}
+  m_SizeDelta: {x: 135.8813, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1318583818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1318583816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1318583819}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1318583819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1318583816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1318583820
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1318583816}
+  m_CullTransparentMesh: 1
 --- !u!114 &1319428894 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 62854736538347116, guid: baee6f97abd3459479c916598232ba22, type: 3}
@@ -2376,6 +3006,83 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1993798801206301794, guid: baee6f97abd3459479c916598232ba22, type: 3}
   m_PrefabInstance: {fileID: 661145530}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1410711695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1410711696}
+  - component: {fileID: 1410711698}
+  - component: {fileID: 1410711697}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1410711696
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1410711695}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 546651229}
+  - {fileID: 1620123530}
+  m_Father: {fileID: 746897330}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -24.7395}
+  m_SizeDelta: {x: 98.448, y: 49.479}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1410711697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1410711695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1410711698
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1410711695}
+  m_CullTransparentMesh: 1
 --- !u!1 &1414121411
 GameObject:
   m_ObjectHideFlags: 0
@@ -2564,6 +3271,140 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1620123529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1620123530}
+  - component: {fileID: 1620123532}
+  - component: {fileID: 1620123531}
+  m_Layer: 5
+  m_Name: Num
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1620123530
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1620123529}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1410711696}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 14.732}
+  m_SizeDelta: {x: 98, y: 29.463}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1620123531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1620123529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 26
+  m_fontSizeBase: 26
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1620123532
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1620123529}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1656553488
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2626,7 +3467,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 142.63345
+      value: 157.36655
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.y
@@ -2662,7 +3503,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 213.95018
+      value: 236.04982
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2785,7 +3626,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 142.63345
+      value: 157.36655
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.y
@@ -2821,7 +3662,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 641.8505
+      value: 708.1495
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2917,7 +3758,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 142.63345
+      value: 157.36655
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_SizeDelta.y
@@ -2953,7 +3794,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 356.58362
+      value: 393.41638
       objectReference: {fileID: 0}
     - target: {fileID: 2157249383083628652, guid: baee6f97abd3459479c916598232ba22, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -2987,6 +3828,81 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1785288478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1785288479}
+  - component: {fileID: 1785288481}
+  - component: {fileID: 1785288480}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1785288479
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1785288478}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 889372135}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -46.895065}
+  m_SizeDelta: {x: 0, y: 93.79013}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1785288480
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1785288478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1785288481
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1785288478}
+  m_CullTransparentMesh: 1
 --- !u!1 &1824905128
 GameObject:
   m_ObjectHideFlags: 0
@@ -3279,13 +4195,13 @@ PrefabInstance:
       propertyPath: m_Name
       value: Hero
       objectReference: {fileID: 0}
-    - target: {fileID: 1248033011169897014, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
-      propertyPath: startPoint.x
+    - target: {fileID: 915783432203821480, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8848269958424033373, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.65
+      value: -0.88
       objectReference: {fileID: 0}
     - target: {fileID: 8848269958424033373, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3293,7 +4209,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8848269958424033373, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 5.93
+      value: 4.51
       objectReference: {fileID: 0}
     - target: {fileID: 8848269958424033373, guid: 576360e9d4dfe384da6bfe1ad4d0b75f, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3416,6 +4332,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1084771388402960298, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 14.980011
+      objectReference: {fileID: 0}
     - target: {fileID: 1346311071942876475, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: m_Value
       value: 1
@@ -3456,6 +4376,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -0.000027656555
       objectReference: {fileID: 0}
+    - target: {fileID: 3980177881256382114, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 14.980011
+      objectReference: {fileID: 0}
     - target: {fileID: 4944141428658221483, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
@@ -3474,7 +4398,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4944141428658221483, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.0024414062
+      value: 0.0024108887
       objectReference: {fileID: 0}
     - target: {fileID: 4944141428658221483, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: m_AnchoredPosition.y
@@ -3485,9 +4409,25 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1218048930}
     - target: {fileID: 7005501786046954680, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: hpBar
+      value: 
+      objectReference: {fileID: 1218048930}
+    - target: {fileID: 7005501786046954680, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: stage
+      value: 
+      objectReference: {fileID: 1620123531}
+    - target: {fileID: 7005501786046954680, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: ExpBar
       value: 
       objectReference: {fileID: 749500180}
+    - target: {fileID: 7005501786046954680, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: expBar
+      value: 
+      objectReference: {fileID: 749500180}
+    - target: {fileID: 7005501786046954680, guid: 748af801eb100954da24e6256356feb2, type: 3}
+      propertyPath: stagePanel
+      value: 
+      objectReference: {fileID: 1410711695}
     - target: {fileID: 8832584231937900903, guid: 748af801eb100954da24e6256356feb2, type: 3}
       propertyPath: m_Name
       value: PlayerInfo

--- a/Assets/YongSeok/Scene/YSGameScene.unity.meta
+++ b/Assets/YongSeok/Scene/YSGameScene.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 54828e6fa2089f5489f6893eaa344c7c
+guid: e8e4c1a437720214e91c01ba90b5852b
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/YongSeok/Scripts/Objects/GameManager.cs
+++ b/Assets/YongSeok/Scripts/Objects/GameManager.cs
@@ -70,6 +70,9 @@ namespace YongSeok
             {
                 TrySpawnHero(HeroType.tankerHero);
             }
+           
+
+
         }
 
         private void TrySpawnHero(HeroType heroType)

--- a/Assets/YongSeok/Scripts/Objects/HeroManager2.cs
+++ b/Assets/YongSeok/Scripts/Objects/HeroManager2.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+public class HeroManager2 : MonoBehaviour
+{
+    private List<Hero> trackedHeroes = new();
+
+    private PlayerHero playerHero; // PlayerHero 참조 추가
+
+    private void Start()
+    {
+        playerHero = FindObjectOfType<PlayerHero>();
+        if (playerHero == null)
+        {
+            Debug.LogError("[HeroManager2] PlayerHero를 찾을 수 없습니다.");
+            return;
+        }
+
+        InvokeRepeating(nameof(ScanHeroes), 0f, 0.2f);
+    }
+    private void ScanHeroes()
+    {
+        Hero[] heroesInScene = FindObjectsOfType<Hero>();
+
+        foreach (var hero in heroesInScene)
+        {
+            if (!trackedHeroes.Contains(hero))
+            {
+                trackedHeroes.Add(hero);
+                Debug.Log($"[HeroManager2] 히어로 감지: {hero.heroname} {hero.star}성");
+            }
+        }
+
+        foreach (var hero in trackedHeroes.ToList())
+        {
+            TryRankUp(hero);
+        }
+    }
+
+    private void TryRankUp(Hero baseHero)
+    {
+        int targetStar = baseHero.star;
+
+
+        string baseKey = baseHero.heroObject.name;
+
+        var matches = trackedHeroes
+            .Where(h => h.heroObject.name == baseKey && h.star == targetStar)
+            .ToList();
+
+        if (matches.Count >= 3)
+        {
+            Debug.Log($"[HeroManager2] 합성 조건 충족 → {baseHero.heroname} {targetStar + 1}성");
+
+            var mergeTargets = matches.Take(3).ToList();
+            Hero last = mergeTargets[2];
+            Vector3 spawnPos = last.transform.position;
+            Vector3Int spawnGrid = last.GetComponent<Unit>().startPoint;
+
+            foreach (var h in mergeTargets)
+            {
+                Vector3Int grid = h.GetComponent<Unit>().startPoint;
+
+                if (grid.y == 3)
+                    playerHero.HeroInStorage[grid] = null;
+                else
+                    playerHero.HeroOnBattle[grid] = null;
+
+                trackedHeroes.Remove(h);
+                Destroy(h.gameObject);
+            }
+
+            SpawnUpgradedHero(baseHero, spawnPos, spawnGrid, last.heroObject);
+        }
+    }
+
+    private void SpawnUpgradedHero(Hero baseHero, Vector3 pos, Vector3Int grid, GameObject prefab)
+    {
+        if (prefab == null)
+        {
+            Debug.LogError("[HeroManager2] 합성용 프리팹이 null입니다.");
+            return;
+        }
+
+        GameObject go = Instantiate(prefab, pos, Quaternion.identity);
+        Hero newHero = go.GetComponent<Hero>();
+
+        newHero.heroname = baseHero.heroname;
+        newHero.star = baseHero.star + 1;
+        newHero.GetComponent<Unit>().startPoint = grid;
+        newHero.SetBattle();
+
+        trackedHeroes.Add(newHero);
+
+        if (grid.y == 3)
+            playerHero.HeroInStorage[grid] = newHero;
+        else
+            playerHero.HeroOnBattle[grid] = newHero;
+
+        Debug.Log($"[HeroManager2] 합성 완료: {newHero.heroname} {newHero.star}성 at {grid}");
+    }
+}

--- a/Assets/YongSeok/Scripts/Objects/HeroManager2.cs.meta
+++ b/Assets/YongSeok/Scripts/Objects/HeroManager2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 520339e45883c4e47854fc7f285d4e67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
PlayerHero에 정보를 가지고 HeroManger2 스크립트를 작성하여 GameManager에 추가하여 구현하고자 했으나 해당 스크립트에서 직접 구현이 필요해 보임. 기존 히어로 제거로 allHero, storageHero에 misssing (Hero)로 카운터가 되어 빈칸이 있음에도 생성이 제한됨. Scene YSGameScene에서 테스트 진행함.