### PR TITLE
[Feat] 배틀매니저, 스폰매니저 추가 및 추적 로직에서 타겟을 바라보는 기능 추가

### DIFF
--- a/Assets/Min/Scenes/TestScene.unity
+++ b/Assets/Min/Scenes/TestScene.unity
@@ -122,7 +122,217 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &8617454
+--- !u!1 &56922423
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 56922424}
+  - component: {fileID: 56922427}
+  - component: {fileID: 56922426}
+  - component: {fileID: 56922425}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &56922424
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56922423}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.08942127, y: 0.34000003, z: 0.37053204}
+  m_LocalScale: {x: 1, y: 0.26018998, z: 0.37515998}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 255122337}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &56922425
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56922423}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &56922426
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56922423}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &56922427
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56922423}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &63052960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 63052961}
+  - component: {fileID: 63052964}
+  - component: {fileID: 63052963}
+  - component: {fileID: 63052962}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &63052961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63052960}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.08942127, y: 0.34000003, z: 0.37053204}
+  m_LocalScale: {x: 1, y: 0.26018998, z: 0.37515998}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1233522200}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &63052962
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63052960}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &63052963
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63052960}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &63052964
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63052960}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &123094692
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -132,15 +342,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.18
+      value: -4.51
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83
+      value: 1.34
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 9.22
+      value: 10.21
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
@@ -172,242 +382,347 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Hero Melee (1)
+      value: Hero Melee
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1267006498}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &353496777
-PrefabInstance:
+--- !u!4 &140770581 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+  m_PrefabInstance: {fileID: 1954459553}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &222891553
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -13.22
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (10)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &369234155
-PrefabInstance:
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 222891554}
+  - component: {fileID: 222891557}
+  - component: {fileID: 222891556}
+  - component: {fileID: 222891555}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &222891554
+Transform:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222891553}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.06
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (5)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &378747185
-PrefabInstance:
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.07000065, y: 0.34000003, z: 0.34000015}
+  m_LocalScale: {x: 1, y: 0.26018998, z: 0.37515998}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 704896900}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &222891555
+BoxCollider:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -4.36
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (3)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &577624570
-PrefabInstance:
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222891553}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &222891556
+MeshRenderer:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222891553}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &222891557
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222891553}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &255122337 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+  m_PrefabInstance: {fileID: 916429965}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &373534175
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 373534176}
+  - component: {fileID: 373534179}
+  - component: {fileID: 373534178}
+  - component: {fileID: 373534177}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &373534176
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373534175}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (2)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &677874733
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.33, z: 0.35}
+  m_LocalScale: {x: 1, y: 0.26019, z: 0.37516123}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1396611492}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &373534177
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373534175}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &373534178
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373534175}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &373534179
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 373534175}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &611101969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 611101970}
+  - component: {fileID: 611101973}
+  - component: {fileID: 611101972}
+  - component: {fileID: 611101971}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &611101970
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611101969}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.447, z: 0.431}
+  m_LocalScale: {x: 0.52203, y: 0.23957, z: 0.2210232}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1371149858}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &611101971
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611101969}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &611101972
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611101969}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &611101973
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611101969}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &704896900 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+  m_PrefabInstance: {fileID: 983158777}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &916429965
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -417,15 +732,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.71
+      value: -0.13
       objectReference: {fileID: 0}
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.05
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 12.251812
+      value: 11.67
       objectReference: {fileID: 0}
     - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
       propertyPath: m_LocalRotation.w
@@ -461,7 +776,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 56922424}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
 --- !u!1 &943676835
@@ -558,7 +876,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1001 &1133159043
+--- !u!1001 &983158777
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -566,56 +884,59 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6.17
+      value: -5.53
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83
+      value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.71
+      value: 5.7
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_Name
-      value: Hero Melee (6)
+      value: Hero Ranger (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 222891554}
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &1172445182
+  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+--- !u!1001 &1055283018
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -623,55 +944,63 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -11.42
+      value: -13.4
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83
+      value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.71
+      value: 5.7
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+    - target: {fileID: 8488796428882984561, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
       propertyPath: m_Name
-      value: Hero Melee (9)
+      value: Hero Ranger
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1735547434}
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+--- !u!4 &1233522200 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+  m_PrefabInstance: {fileID: 1710047849}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1237570186
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -729,63 +1058,121 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50d8dd2d44c8dcc448310da52ca3662e, type: 3}
---- !u!1001 &1281549100
-PrefabInstance:
+--- !u!1 &1267006497
+GameObject:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1267006498}
+  - component: {fileID: 1267006501}
+  - component: {fileID: 1267006500}
+  - component: {fileID: 1267006499}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1267006498
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267006497}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.65
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (4)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.447, z: 0.431}
+  m_LocalScale: {x: 0.52203, y: 0.23957, z: 0.2210232}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2127750718}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1267006499
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267006497}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1267006500
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267006497}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1267006501
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267006497}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1371149858 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+  m_PrefabInstance: {fileID: 2074486038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1396611492 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+  m_PrefabInstance: {fileID: 1960304623}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1499918983
 GameObject:
   m_ObjectHideFlags: 0
@@ -878,7 +1265,297 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1509386450
+--- !u!1001 &1710047849
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152927933751008845, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      propertyPath: m_Name
+      value: Monster Melee
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 560843773711746409, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 63052961}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d26febc23b08b4ba5cc93f2c06a616, type: 3}
+--- !u!1 &1735547433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1735547434}
+  - component: {fileID: 1735547437}
+  - component: {fileID: 1735547436}
+  - component: {fileID: 1735547435}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1735547434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735547433}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.07000065, y: 0.34000003, z: 0.34000015}
+  m_LocalScale: {x: 1, y: 0.26018998, z: 0.37515998}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1959161618}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1735547435
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735547433}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1735547436
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735547433}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1735547437
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735547433}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1954459553
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_Name
+      value: Monster Ranger
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2135969238}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+--- !u!4 &1959161618 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3574251028138415600, guid: 3388643a90d4ab74c95ff2445e23527b, type: 3}
+  m_PrefabInstance: {fileID: 1055283018}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1960304623
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 16.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7664697950509709105, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      propertyPath: m_Name
+      value: Monster Ranger (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 750738757089174787, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 373534176}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06dadf9422f985345baeaca6935449ff, type: 3}
+--- !u!1001 &2074486038
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -888,15 +1565,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -7.93
+      value: -11.13
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.83
+      value: 1.34
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.71
+      value: 10.21
       objectReference: {fileID: 0}
     - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_LocalRotation.w
@@ -928,70 +1605,126 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
       propertyPath: m_Name
-      value: Hero Melee (7)
+      value: Hero Melee (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 611101970}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
---- !u!1001 &1600174940
-PrefabInstance:
+--- !u!4 &2127750718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+  m_PrefabInstance: {fileID: 123094692}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2135969237
+GameObject:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2135969238}
+  - component: {fileID: 2135969241}
+  - component: {fileID: 2135969240}
+  - component: {fileID: 2135969239}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2135969238
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2135969237}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -9.49
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.83
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.71
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2357903795028269578, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6958677851766078136, guid: 467ce242d8b17344fa7502c932038714, type: 3}
-      propertyPath: m_Name
-      value: Hero Melee (8)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 467ce242d8b17344fa7502c932038714, type: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.33, z: 0.35}
+  m_LocalScale: {x: 1, y: 0.26019, z: 0.37516123}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 140770581}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2135969239
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2135969237}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2135969240
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2135969237}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2135969241
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2135969237}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -999,14 +1732,11 @@ SceneRoots:
   - {fileID: 1499918986}
   - {fileID: 943676837}
   - {fileID: 1237570186}
-  - {fileID: 677874733}
-  - {fileID: 8617454}
-  - {fileID: 577624570}
-  - {fileID: 1281549100}
-  - {fileID: 369234155}
-  - {fileID: 1133159043}
-  - {fileID: 1509386450}
-  - {fileID: 1600174940}
-  - {fileID: 1172445182}
-  - {fileID: 353496777}
-  - {fileID: 378747185}
+  - {fileID: 123094692}
+  - {fileID: 2074486038}
+  - {fileID: 1954459553}
+  - {fileID: 1960304623}
+  - {fileID: 1055283018}
+  - {fileID: 983158777}
+  - {fileID: 1710047849}
+  - {fileID: 916429965}

--- a/Assets/Min/Scripts/BattleManager.cs
+++ b/Assets/Min/Scripts/BattleManager.cs
@@ -13,30 +13,6 @@ public class BattleManager : MonoBehaviour
     private int heroCounts;
     private int monsterCounts;
 
-    private void Awake()
-    {
-        SetSingleton();
-
-        // 이벤트 구독
-        // 라운드 시작 시 발생하는 이벤트 GetHeroNumbers 구독
-        // 스폰 매니저에서 스폰될 때 GetMonsterNumbers 호출
-        // 오브젝트가 죽었을 때 발생하는 이벤트 CheckVictory 구독
-    }
-
-    // 각자 싱글톤 or 게임매니저에서 본 클래스 사용?
-    private void SetSingleton()
-    {
-        if (instance != null)
-        {
-            Destroy(gameObject);
-        }
-        else
-        {
-            instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-    }
-
     // 라운드 시작 시 호출
     public void GetHeroNumbers()
     {
@@ -45,6 +21,7 @@ public class BattleManager : MonoBehaviour
     }
 
     // 스폰 매니저에서 스폰될 때마다 호출
+    // 한 번에 값 전부
     public void GetMonsterNumbers(int numbers)
     {
         monsterCounts += numbers;
@@ -61,7 +38,8 @@ public class BattleManager : MonoBehaviour
 
             //GameManager.Instance.player.Gold -= GameManager.Instance.player.Gold / 10;
 
-            shopPanel.SetActive(true);
+            // 샵 매니저로 - 롤체는 계속 켜져있기 때문에
+            //shopPanel.SetActive(true);
         }
 
         // 승리
@@ -69,7 +47,7 @@ public class BattleManager : MonoBehaviour
         {
             GameManager.Instance.player.Stage++;
 
-            shopPanel.SetActive(true);
+            //shopPanel.SetActive(true);
         }
     }
 }

--- a/Assets/Min/Scripts/BattleManager.cs
+++ b/Assets/Min/Scripts/BattleManager.cs
@@ -1,0 +1,75 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using UnityEngine;
+
+public class BattleManager : MonoBehaviour
+{
+    [SerializeField] GameObject shopPanel;
+
+    private static BattleManager instance;
+    public static BattleManager Instance { get { return instance; } }
+
+    private int heroCounts;
+    private int monsterCounts;
+
+    private void Awake()
+    {
+        SetSingleton();
+
+        // 이벤트 구독
+        // 라운드 시작 시 발생하는 이벤트 GetHeroNumbers 구독
+        // 스폰 매니저에서 스폰될 때 GetMonsterNumbers 호출
+        // 오브젝트가 죽었을 때 발생하는 이벤트 CheckVictory 구독
+    }
+
+    // 각자 싱글톤 or 게임매니저에서 본 클래스 사용?
+    private void SetSingleton()
+    {
+        if (instance != null)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+
+    // 라운드 시작 시 호출
+    public void GetHeroNumbers()
+    {
+        GameObject[] heroTargets = GameObject.FindGameObjectsWithTag("Hero");
+        heroCounts = heroTargets.Length;
+    }
+
+    // 스폰 매니저에서 스폰될 때마다 호출
+    public void GetMonsterNumbers(int numbers)
+    {
+        monsterCounts += numbers;
+    }
+
+    // 오브젝트가 죽었을 때 호출
+    public void CheckVictory()
+    {
+        // 패배
+        if (heroCounts <= 0)
+        {
+            GameObject[] monsters = GameObject.FindGameObjectsWithTag("Monster");
+            GameManager.Instance.player.Health -= monsters.Length * 3;
+
+            //GameManager.Instance.player.Gold -= GameManager.Instance.player.Gold / 10;
+
+            shopPanel.SetActive(true);
+        }
+
+        // 승리
+        else if (monsterCounts <= 0)
+        {
+            GameManager.Instance.player.Stage++;
+
+            shopPanel.SetActive(true);
+        }
+    }
+}

--- a/Assets/Min/Scripts/BattleManager.cs.meta
+++ b/Assets/Min/Scripts/BattleManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8413247e37e94f34e8eae3dc7e05131d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/HexCellDebuggger.cs
+++ b/Assets/Min/Scripts/HexCellDebuggger.cs
@@ -8,15 +8,15 @@ public class HexCellDebuggger : MonoBehaviour
     [SerializeField] Tilemap tilemap;
 
     public Vector2Int currentCellPos;
-
+    public Vector3 currentWorldCenter;
     private void Update()
     {
         if (tilemap == null) return;
 
         Vector3 worldPos = transform.position;
-
         Vector3Int cellPos = tilemap.WorldToCell(worldPos);
-
         currentCellPos = new Vector2Int(cellPos.x, cellPos.y);
+
+        currentWorldCenter = tilemap.GetCellCenterWorld(cellPos);
     }
 }

--- a/Assets/Min/Scripts/InfectionZombie1.cs
+++ b/Assets/Min/Scripts/InfectionZombie1.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class InfectionZombie1 : Zombie
+{
+    protected override string Name { get ; set; }
+    protected override int CurrentHealth { get; set; }
+    protected override int MaxHealth { get; set; }
+    protected override int Power { get; set; }
+    protected override float AttackSpeed { get; set; }
+    protected override float MoveSpeed { get; set; }
+    protected override int Level { get; set; }
+    protected override int DropGold { get; set; }
+    protected override int DropExp { get; set; } // 삭제
+    protected override float AttackRange { get; set; }
+
+
+    protected void InfectionAttack(GameObject target)
+    {
+        //IDamagable damagable = target.GetComponent<IDamagable>();
+
+        //if (damagable != null)
+        //    damagable.TakeDamage(damagable.MaxHealth / 3);
+
+        //if (damagable.CurrentHealth <= 0)
+        //{
+        //    Vector3 spawnPos = damagable.Position;
+
+        //    Instantiate(좀비 프리팹, spawnPos, Quaternion.identity);
+        //}
+    }
+}

--- a/Assets/Min/Scripts/InfectionZombie1.cs.meta
+++ b/Assets/Min/Scripts/InfectionZombie1.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c36fbf9c6ae95204ab594da0643b5f0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/SpawnManager.cs
+++ b/Assets/Min/Scripts/SpawnManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
@@ -13,6 +14,14 @@ public class SpawnManager : MonoBehaviour
 
     [SerializeField] Tilemap tilemap;
 
+    private Vector2Int leftUpPoint = new Vector2Int(-8, 11);
+    private Vector2Int middleUpPoint = new Vector2Int(-4, 11);
+    private Vector2Int rightUpPoint = new Vector2Int(0, 11);
+    private Vector2Int leftDownPoint = new Vector2Int(-8, 8);
+    private Vector2Int middleDownPoint = new Vector2Int(-4, 8);
+    private Vector2Int rightDownPoint = new Vector2Int(0, 8);
+
+
     private Coroutine SpawnCoroutine;
     private int spawnWave;
 
@@ -23,7 +32,7 @@ public class SpawnManager : MonoBehaviour
         {
             case 1:
                 spawnWave = 1;
-                //SpawnCoroutine = StartCoroutine(SpawnRoutine);
+                SpawnCoroutine = StartCoroutine(SpawnRoutine());
                 break;
 
             case 2:
@@ -32,11 +41,13 @@ public class SpawnManager : MonoBehaviour
         }
     }
 
+    // 라운드 종료 시 호출
     private void EndRound()
     {
-
+        StopCoroutine(SpawnCoroutine);
     }
 
+    // 셀 좌표로 소환하기 위한 메서드
     private void SpawnAt(Vector2Int gridPos, GameObject prefab)
     {
         Vector3Int cell = new Vector3Int(gridPos.x, gridPos.y, 0);
@@ -48,15 +59,15 @@ public class SpawnManager : MonoBehaviour
 
     IEnumerator SpawnRoutine()
     {
-        if (spawnWave != 0)
+        while (spawnWave > 0)
         {
+            // 스폰 포인트 변수화 가능
             SpawnAt(new Vector2Int(-4, 8), normalMonsterPrefab);
+            BattleManager.Instance.GetMonsterNumbers(1);
             spawnWave--;
             yield return new WaitForSeconds(spawnDelay);
         }
-        else
-        {
 
-        }
+        yield break;
     }
 }

--- a/Assets/Min/Scripts/SpawnManager.cs
+++ b/Assets/Min/Scripts/SpawnManager.cs
@@ -6,14 +6,15 @@ using UnityEngine.Tilemaps;
 
 public class SpawnManager : MonoBehaviour
 {
-    [SerializeField] float spawnDelay;
     [SerializeField] float ObjYPos = 1.5f;
 
+    // TODO: 기물 종류 추가
     [SerializeField] GameObject normalMonsterPrefab;
     [SerializeField] GameObject rangerMonsterPrefab;
 
     [SerializeField] Tilemap tilemap;
 
+    // 스폰 포인트
     private Vector2Int leftUpPoint = new Vector2Int(-8, 11);
     private Vector2Int middleUpPoint = new Vector2Int(-4, 11);
     private Vector2Int rightUpPoint = new Vector2Int(0, 11);
@@ -21,9 +22,8 @@ public class SpawnManager : MonoBehaviour
     private Vector2Int middleDownPoint = new Vector2Int(-4, 8);
     private Vector2Int rightDownPoint = new Vector2Int(0, 8);
 
-
     private Coroutine SpawnCoroutine;
-    private int spawnWave;
+    private int spawnCount;
 
     // 라운드 시작 시 호출
     private void Spawn()
@@ -31,12 +31,12 @@ public class SpawnManager : MonoBehaviour
         switch (GameManager.Instance.player.Stage)
         {
             case 1:
-                spawnWave = 1;
+                spawnCount = 2;
                 SpawnCoroutine = StartCoroutine(SpawnRoutine());
                 break;
 
             case 2:
-                spawnWave = 2;
+                spawnCount = 3;
                 break;
         }
     }
@@ -55,19 +55,126 @@ public class SpawnManager : MonoBehaviour
         worldPos.y = ObjYPos;
 
         Instantiate(prefab, worldPos, Quaternion.identity);
+        // TODO: z-를 보게 소환
     }
 
     IEnumerator SpawnRoutine()
     {
-        while (spawnWave > 0)
+        while (spawnCount <= 0)
         {
-            // 스폰 포인트 변수화 가능
-            SpawnAt(new Vector2Int(-4, 8), normalMonsterPrefab);
-            BattleManager.Instance.GetMonsterNumbers(1);
-            spawnWave--;
-            yield return new WaitForSeconds(spawnDelay);
+            if (IsCellEmpty(leftUpPoint))
+            {
+                SpawnAt(leftUpPoint, returnRandomMonsterType());
+                spawnCount--;
+            }
+            if (IsCellEmpty(middleUpPoint))
+            {
+                SpawnAt(middleUpPoint, returnRandomMonsterType());
+                spawnCount--;
+            }
+            if (IsCellEmpty(rightUpPoint))
+            {
+                SpawnAt(rightUpPoint, returnRandomMonsterType());
+                spawnCount--;
+            }
+            // TODO: 아래쪽에도 같은 방식으로 소환
         }
 
         yield break;
+    }
+
+    // 셀이 비어있는지 확인
+    private bool IsCellEmpty(Vector2Int cellPos)
+    {
+        GameObject[] heros = GameObject.FindGameObjectsWithTag("Hero");
+        GameObject[] enemies = GameObject.FindGameObjectsWithTag("Monster");
+
+        List<GameObject> allUnits = new List<GameObject>();
+
+        allUnits.AddRange(heros);
+        allUnits.AddRange(enemies);
+
+        foreach (GameObject unit in allUnits)
+        {
+            Vector3 world = unit.transform.position;
+            Vector3Int cell = tilemap.WorldToCell(world);
+            Vector2Int unitPos = new Vector2Int(cell.x, cell.y);
+
+            if (unitPos == cellPos)
+                return false;
+        }
+
+        return true;
+    }
+
+    // 랜덤으로 기물을 반환하는 메서드
+    // TODO: 만약 앞쪽 행에 원거리 금지, 뒤쪽 행에 근거리 금지면 조건문 추가
+    // TODO: 확률 조절은 Range를 늘리고 if문에서 조건식 수정
+    private GameObject returnRandomMonsterType()
+    {
+        if (GameManager.Instance.player.Stage == 1)
+        {
+            return normalMonsterPrefab;
+        }
+
+        // 2 ~ 5
+        else if (GameManager.Instance.player.Stage >= 2 && GameManager.Instance.player.Stage <= 5)
+        {
+            int randomNum = Random.Range(0, 1);
+
+            if (randomNum == 0)
+            {
+                return normalMonsterPrefab;
+            }
+            else
+            {
+                return rangerMonsterPrefab;
+            }
+        }
+
+        // 6 ~ 10
+        else if (GameManager.Instance.player.Stage >= 6 && GameManager.Instance.player.Stage <= 10)
+        {
+            int randomNum = Random.Range(0, 1);
+
+            if (randomNum == 0)
+            {
+                return normalMonsterPrefab;
+            }
+            else
+            {
+                return rangerMonsterPrefab;
+            }
+        }
+
+        // 11 ~ 15
+        else if (GameManager.Instance.player.Stage >= 11 && GameManager.Instance.player.Stage <= 15)
+        {
+            int randomNum = Random.Range(0, 1);
+
+            if (randomNum == 0)
+            {
+                return normalMonsterPrefab;
+            }
+            else
+            {
+                return rangerMonsterPrefab;
+            }
+        }
+
+        // 16 ~ 20
+        else
+        {
+            int randomNum = Random.Range(0, 1);
+
+            if (randomNum == 0)
+            {
+                return normalMonsterPrefab;
+            }
+            else
+            {
+                return rangerMonsterPrefab;
+            }
+        }
     }
 }

--- a/Assets/Min/Scripts/SpawnManager.cs
+++ b/Assets/Min/Scripts/SpawnManager.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+public class SpawnManager : MonoBehaviour
+{
+    [SerializeField] float spawnDelay;
+    [SerializeField] float ObjYPos = 1.5f;
+
+    [SerializeField] GameObject normalMonsterPrefab;
+    [SerializeField] GameObject rangerMonsterPrefab;
+
+    [SerializeField] Tilemap tilemap;
+
+    private Coroutine SpawnCoroutine;
+    private int spawnWave;
+
+    // 라운드 시작 시 호출
+    private void Spawn()
+    {
+        switch (GameManager.Instance.player.Stage)
+        {
+            case 1:
+                spawnWave = 1;
+                //SpawnCoroutine = StartCoroutine(SpawnRoutine);
+                break;
+
+            case 2:
+                spawnWave = 2;
+                break;
+        }
+    }
+
+    private void EndRound()
+    {
+
+    }
+
+    private void SpawnAt(Vector2Int gridPos, GameObject prefab)
+    {
+        Vector3Int cell = new Vector3Int(gridPos.x, gridPos.y, 0);
+        Vector3 worldPos = tilemap.GetCellCenterWorld(cell);
+        worldPos.y = ObjYPos;
+
+        Instantiate(prefab, worldPos, Quaternion.identity);
+    }
+
+    IEnumerator SpawnRoutine()
+    {
+        if (spawnWave != 0)
+        {
+            SpawnAt(new Vector2Int(-4, 8), normalMonsterPrefab);
+            spawnWave--;
+            yield return new WaitForSeconds(spawnDelay);
+        }
+        else
+        {
+
+        }
+    }
+}

--- a/Assets/Min/Scripts/SpawnManager.cs.meta
+++ b/Assets/Min/Scripts/SpawnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a07af259fa5a4ee4185b2ee7438d9ac6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Min/Scripts/Test/TraceTest.cs
+++ b/Assets/Min/Scripts/Test/TraceTest.cs
@@ -25,22 +25,28 @@ public class TraceTest : MonoBehaviour
         if (tilemap == null)
             tilemap = FindObjectOfType<Tilemap>();
 
-        // TODO: 게임 시작 버튼이 눌렸을 때, StartCoroutine -> 이벤트 구독
-        // TODO: Player 클래스에서 
-        // TODO: battle 중인지 아닌지 - NonBattleHero 태그로 추가해주심
+
+        // TODO: 이벤트 구독 시 아래 코드 2줄 삭제
         if (gameObject.CompareTag("Monster") || gameObject.CompareTag("Hero"))
             unitCoroutine = StartCoroutine(UnitRoutine());
 
         // TODO: 게임이 끝났을 때, TileReservation.Clear();
 
-        // 이벤트이름.AddListener(StartCoroutine);
+        // 클래스이름.OnBattlingChanged += StartCoroutine;
     }
 
     // 구독용 함수
     private void StartCoroutine()
     {
-        if (gameObject.CompareTag("Monster") || gameObject.CompareTag("Hero"))
-            unitCoroutine = StartCoroutine(UnitRoutine());
+        //if (클래스이름.battling) // 클래스가 static이 아니면, 필드에 클래스 추가
+        //{
+        //    if (gameObject.CompareTag("Monster") || gameObject.CompareTag("Hero"))
+        //        unitCoroutine = StartCoroutine(UnitRoutine());
+        //}
+        //else
+        //{
+        //    StopCoroutine(unitCoroutine);
+        //}
     }
 
 
@@ -73,6 +79,7 @@ public class TraceTest : MonoBehaviour
                 {
                     Debug.Log($"{gameObject.name}공격, {target.name}피격");
                     // TODO: 데미지
+                    // 
                     yield return new WaitForSeconds(moveInterval);
                     // 공격 속도용 변수 추가 moveInterval 대신 넣어서 구현 가능
                     continue;

--- a/Assets/Min/Scripts/Test/TraceTest.cs
+++ b/Assets/Min/Scripts/Test/TraceTest.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using TMPro;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Tilemaps;
@@ -32,11 +33,11 @@ public class TraceTest : MonoBehaviour
 
         // TODO: 게임이 끝났을 때, TileReservation.Clear();
 
-        // 클래스이름.OnBattlingChanged += StartCoroutine;
+        // 클래스이름.OnBattlingChanged += BattleOnOff;
     }
 
     // 구독용 함수
-    private void StartCoroutine()
+    private void BattleOnOff()
     {
         //if (클래스이름.battling) // 클래스가 static이 아니면, 필드에 클래스 추가
         //{
@@ -77,9 +78,11 @@ public class TraceTest : MonoBehaviour
 
                 if (dist <= attackRange)
                 {
+                    // TODO: 이동 방향 부드럽게 바라보기
+                    transform.LookAt(target.position);
+
                     Debug.Log($"{gameObject.name}공격, {target.name}피격");
-                    // TODO: 데미지
-                    // 
+                    // TODO: 데미지             
                     yield return new WaitForSeconds(moveInterval);
                     // 공격 속도용 변수 추가 moveInterval 대신 넣어서 구현 가능
                     continue;
@@ -107,6 +110,9 @@ public class TraceTest : MonoBehaviour
     private IEnumerator MoveTo(Vector3 targetPos)
     {
         isMoving = true;
+
+        // TODO: 이동 방향 부드럽게 바라보기
+        transform.LookAt(targetPos);
 
         Vector3 start = transform.position;
         float t = 0f;


### PR DESCRIPTION
1. 적 기물 소환을 위한 SpawnManager 클래스 추가
2. 라운드 별 승패 판단을 위한 BattleManager 클래스 추가
3. 추적 로직에서 이동 시 이동할 칸을 바라보게, 적 공격 시 공격할 적을 바라보는 기능 추가
4. 디버깅용 HexCellDebuggger 클래스에 Cell to World 좌표 변환 기능 추가
5. 감염 좀비 특수 능력 테스트 메서드 추가